### PR TITLE
[Fixed] already set initial setting for Rspec

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,5 +41,6 @@ module Achieve
         request_specs: false
       g.fixture_replacement :factory_girl, dir: "spec/factories"
     end
+
   end
 end


### PR DESCRIPTION
already set initial setting for Rspec.
detail codes are below.

.rspec
```
--format documentation
```

config/application.rb
```
    config.generators do |g|
      g.test_framework :rspec,
        fixtures: true,
        view_specs: false,
        helper_specs: false,
        routing_specs: false,
        controller_specs: true,
        request_specs: false
      g.fixture_replacement :factory_girl, dir: "spec/factories"
    end
```